### PR TITLE
Way for heroku apps to pull requirements from private repositories

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -50,3 +50,36 @@ Runtime options include:
 - pypy3-2.3.1 (unsupported, experimental)
 
 Other [unsupported runtimes](https://github.com/heroku/heroku-buildpack-python/tree/master/builds/runtimes) are available as well.
+
+
+Specify an SSH Key
+------------------
+
+If you need to install dependencies stored in private repositories, but you don't want to hardcode passwords in the code,
+you can use the following approach.
+
+
+- Generate or use an existing a new SSH key pair (https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/)
+
+  For this example, assume that you named the key `deploy_key`.
+
+- Add the public ssh key to your private repository account.
+
+  * Github: https://help.github.com/articles/adding-a-new-ssh-key-to-your-github-account/
+
+  * Bitbucket: https://confluence.atlassian.com/bitbucket/add-an-ssh-key-to-an-account-302811853.html
+
+- Add CUSTOM_SSH_KEY and CUSTOM_SSH_KEY_HOSTS environment variables to you heroku app
+
+  * CUSTOM_SSH_KEY must be base64 encoded
+  * CUSTOM_SSH_KEY_HOSTS is a comma separated list of the hosts that will use the custom SSH key
+
+  ```
+  # OSX
+  $ heroku config:set CUSTOM_SSH_KEY=$(base64 --input ~/.ssh/deploy_key.pub) CUSTOM_SSH_KEY_HOSTS=bitbucket.org,github.com
+
+  # Linux
+  $ heroku config:set CUSTOM_SSH_KEY=$(base64 ~/.ssh/deploy_key.pub | tr -d '\n') CUSTOM_SSH_KEY_HOSTS=bitbucket.org,github.com
+  ```
+
+- Deploy your app and enjoy!

--- a/bin/compile
+++ b/bin/compile
@@ -147,6 +147,9 @@ set -e
 
 mkdir -p $(dirname $PROFILE_PATH)
 
+# Set Up SSH deploy-key.
+source $BIN_DIR/steps/sshkey
+
 # Install Python.
 source $BIN_DIR/steps/python
 

--- a/bin/steps/sshkey
+++ b/bin/steps/sshkey
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Generates an SSH config file for connections if a config var exists.
+
+# ENV_DIR=$3
+
+if [[ -f $ENV_DIR/CUSTOM_SSH_KEY && -f $ENV_DIR/CUSTOM_SSH_KEY_HOSTS ]]; then
+
+  #echo "" >&1
+  echo ""
+
+  # Ensure we have an ssh folder
+  if [ ! -d ~/.ssh ]; then
+    mkdir -p ~/.ssh
+    chmod 700 ~/.ssh
+  fi
+
+  # Load the private key into custom_key file.
+  base64 --decode $ENV_DIR/CUSTOM_SSH_KEY > ~/.ssh/custom_key
+
+  # Change the permissions on the file to
+  # be read-only for this user.
+  chmod 400 ~/.ssh/custom_key
+
+  # Split $CUSTOM_SSH_KEY_HOSTS
+  (
+    IFS=',' ;for element in `cat $ENV_DIR/CUSTOM_SSH_KEY_HOSTS`;
+    do
+      echo -e "Host $element\n"\
+              "  IdentityFile ~/.ssh/custom_key\n"\
+              "  IdentitiesOnly yes\n"\
+              "  UserKnownHostsFile=/dev/null\n"\
+              "  StrictHostKeyChecking no"\
+              >> ~/.ssh/config
+    done
+
+    echo "-----> Successfully added custom SSH key"
+  )
+fi


### PR DESCRIPTION
Adapted from https://github.com/simon0191/custom-ssh-key-buildpack

### Goal
We want to remove github tokens from `requirements.txt` files for security reasons, but for heroku apps that need to download requirements from private repositories we need an alternative way to access them. The proposed solution is to configure those apps with appropriate config variables (cf., updates to README.md) and to use a step that sets up the ssh key. 

### Test
Manually tested this with master-deploy-api and it works as expected both when the config variables are present and when they are missing (-> the ssh-key setup step is skipped in that case)